### PR TITLE
fix: check for empty message

### DIFF
--- a/main.go
+++ b/main.go
@@ -31,7 +31,6 @@ import (
 )
 
 func main() {
-	fmt.Println("HELLO PEOPLE> I HAVE TAKEN CONTROL HAHAHA")
 	topic := os.Getenv("PULSAR_TOPIC")
 	subscriptionName := os.Getenv("PULSAR_SUBSCRIPTION_NAME")
 	host := os.Getenv("PULSAR_HOST")

--- a/main.go
+++ b/main.go
@@ -31,6 +31,7 @@ import (
 )
 
 func main() {
+	fmt.Println("HELLO PEOPLE> I HAVE TAKEN CONTROL HAHAHA")
 	topic := os.Getenv("PULSAR_TOPIC")
 	subscriptionName := os.Getenv("PULSAR_SUBSCRIPTION_NAME")
 	host := os.Getenv("PULSAR_HOST")

--- a/pkg/apachepulsar/pulsar_source.go
+++ b/pkg/apachepulsar/pulsar_source.go
@@ -60,7 +60,6 @@ func (ps *PulsarSource) Read(_ context.Context, readRequest sourcesdk.ReadReques
 			} else if err != nil {
 				log.Printf("error receiving message %s", err)
 			} else {
-				log.Println("got message!")
 				messageCh <- sourcesdk.NewMessage(
 					msg.Payload(),
 					sourcesdk.NewOffset([]byte(msg.ID().String()), 0),

--- a/pkg/apachepulsar/pulsar_source.go
+++ b/pkg/apachepulsar/pulsar_source.go
@@ -55,8 +55,15 @@ func (ps *PulsarSource) Read(_ context.Context, readRequest sourcesdk.ReadReques
 		default:
 			ps.lock.Lock()
 			msg, err := ps.consumer.Receive(ctx)
+			if msg == nil {
+				log.Println("received empty message")
+				ps.lock.Unlock()
+				continue
+			}
 			if err != nil {
 				log.Printf("error receiving message %s", err)
+				ps.lock.Unlock()
+				continue
 			}
 			messageCh <- sourcesdk.NewMessage(
 				msg.Payload(),

--- a/pkg/apachepulsar/pulsar_source.go
+++ b/pkg/apachepulsar/pulsar_source.go
@@ -70,7 +70,6 @@ func (ps *PulsarSource) Read(_ context.Context, readRequest sourcesdk.ReadReques
 				msg.PublishTime(),
 			)
 			ps.toAckSet[msg.ID().String()] = msg
-			ps.lock.Unlock()
 		}
 	}
 }

--- a/pkg/apachepulsar/pulsar_source.go
+++ b/pkg/apachepulsar/pulsar_source.go
@@ -54,15 +54,14 @@ func (ps *PulsarSource) Read(_ context.Context, readRequest sourcesdk.ReadReques
 			return
 		default:
 			ps.lock.Lock()
+			defer ps.lock.Unlock()
 			msg, err := ps.consumer.Receive(ctx)
 			if msg == nil {
 				log.Println("received empty message")
-				ps.lock.Unlock()
 				continue
 			}
 			if err != nil {
 				log.Printf("error receiving message %s", err)
-				ps.lock.Unlock()
 				continue
 			}
 			messageCh <- sourcesdk.NewMessage(


### PR DESCRIPTION
Hey!

I was finding that the source would continually crash if there were no messages in the topic. This would occur as `Receive` would timeout after 1 second and return an empty message. The empty message would then be called with `msg.Payload()`

This change just checks for an empty message and continues if so. Also add's a `ps.locl.Unlock()` and `continue` if an error occurs

Should note this is my first time writing golang so apologies if there are formatting errors or anything